### PR TITLE
Configure application to run on I/O thread pool

### DIFF
--- a/micronaut-app/src/main/resources/application.yml
+++ b/micronaut-app/src/main/resources/application.yml
@@ -3,6 +3,7 @@ micronaut:
     name: MicronautApp
   server:
     port: 8702
+    thread-selection: IO
 netty:
   default:
     allocator:


### PR DESCRIPTION
The application is using blocking I/O and not reactive so the server should be configured to run requests on a separate IO thread otherwise this will lead to thread contention with the event loop in benchmarks.