### PR TITLE
Added clarification on the UNIQUE_IDENTIFIER

### DIFF
--- a/docs/src/docs/asciidoc/01-setup/setup.adoc
+++ b/docs/src/docs/asciidoc/01-setup/setup.adoc
@@ -199,6 +199,7 @@ For that, we use the `UNIQUE_IDENTIFIER` environment variable to make sure we do
 If you are developing in your local machine, the `UNIQUE_IDENTIFIER` will be your username (which is not totally unique, but it's a good start).
 On the other hand, if you're using the DevContainer, you must manually set this to a unique value (like your name) to avoid conflicts with other users
 So, if you use DevContainer, make sure to set the `UNIQUE_IDENTIFIER` environment variable to a unique value.
+Please make sure to use a lowercase value, as it's used as a suffix to create resources that cannot stand uppercase.
 ====
 
 [source,shell]


### PR DESCRIPTION
I changed some letters in UNIQUE_IDENTIFIER to uppercase and then the container registry creation fails.